### PR TITLE
fix: use responsive 100% height for map container

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,8 @@
 </template>
 
 <style>
-/* import vuetify css */
-@import url("//fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons");
-@import url("//cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css");
 /* import material design icons css*/
+@import url("//fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons");
 @import url("//cdn.materialdesignicons.com/3.6.95/css/materialdesignicons.min.css");
 
 #nav {

--- a/src/components/mb-map.vue
+++ b/src/components/mb-map.vue
@@ -87,7 +87,7 @@ export default class MbMap extends Vue {
 @import url("//api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css");
 
 .mgl-map-wrapper {
-  height: 500px;
+  height: 100%;
   position: relative;
   width: 100%;
 }

--- a/src/components/mb-map.vue
+++ b/src/components/mb-map.vue
@@ -84,7 +84,6 @@ export default class MbMap extends Vue {
 </script>
 
 <style>
-@import url("//api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css");
 
 .mgl-map-wrapper {
   height: 100%;

--- a/src/components/mb-map.vue
+++ b/src/components/mb-map.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mgl-map-wrapper">
     <div v-once :id="mapId" ref="container"/>
-    <slot/>
+    <slot v-if="initialized"/>
   </div>
 </template>
 
@@ -91,12 +91,14 @@ export default class MbMap extends Vue {
   position: relative;
   width: 100%;
 }
-.mgl-map-wrapper .mapboxgl-map {
+.mgl-map-wrapper 
+
+.mapboxgl-map {
   height: 100%;
   width: 100%;
   position: absolute;
   top: 0;
-  bottom: 0;
+  left: 0;
 }
 </style>
 

--- a/src/components/mb-map.vue
+++ b/src/components/mb-map.vue
@@ -18,8 +18,8 @@ import mapboxgl from "mapbox-gl";
 
 @Component
 export default class MbMap extends Vue {
-  initial: boolean = true;
-  initialized: boolean = false;
+  public initial: boolean = true;
+  public initialized: boolean = false;
 
   private map?: mapboxgl.Map = undefined;
 
@@ -31,7 +31,7 @@ export default class MbMap extends Vue {
 
   public mounted() {
     mapboxgl.accessToken = this.accessToken;
-    let map = new mapboxgl.Map({
+    const map = new mapboxgl.Map({
       ...this.mapOptions,
       container: this.mapId || this.$refs.container,
       style: this.mapStyle
@@ -45,23 +45,23 @@ export default class MbMap extends Vue {
     });
   }
 
-  @Emit("load") public mapLoaded() {
+  @Emit('load') public mapLoaded() {
     return {
       map: this.map,
-      component: this
+      component: this,
     };
   }
 
-  @Watch("mapStyle")
+  @Watch('mapStyle')
   public onMapStyleChanged(nextStyle: string, prev: string) {
-    if (nextStyle != prev) {
+    if (nextStyle !== prev) {
       (this.map as mapboxgl.Map).setStyle(nextStyle);
     }
   }
 
-  @Provide("handlemap")
+  @Provide('handlemap')
   public handlemap(found: (map: mapboxgl.Map) => void) {
-    let vm = this;
+    const vm = this;
     function checkForMap() {
       if (vm.map) {
         found(vm.map);
@@ -74,11 +74,11 @@ export default class MbMap extends Vue {
   }
 
   public addMarker() {
-    let marker = new mapboxgl.Marker({
-      draggable: true
+    const marker = new mapboxgl.Marker({
+      draggable: true,
     })
       .setLngLat(this.mapOptions.center as mapboxgl.LngLatLike)
-      .addTo(<mapboxgl.Map>this.map);
+      .addTo(this.map as mapboxgl.Map);
   }
 }
 </script>
@@ -91,9 +91,7 @@ export default class MbMap extends Vue {
   position: relative;
   width: 100%;
 }
-.mgl-map-wrapper 
-
-.mapboxgl-map {
+.mgl-map-wrapper .mapboxgl-map {
   height: 100%;
   width: 100%;
   position: absolute;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import router from './router';
 import store from './store';
 import Vuetify from 'vuetify';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import 'vuetify/dist/vuetify.min.css';
 
 Vue.config.productionTip = false;
 Vue.use(Vuetify);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import Vuetify from 'vuetify';
+import 'mapbox-gl/dist/mapbox-gl.css';
 
 Vue.config.productionTip = false;
 Vue.use(Vuetify);

--- a/src/views/Dynamic.vue
+++ b/src/views/Dynamic.vue
@@ -1,24 +1,27 @@
 <template>
-  <div>
-    <mb-map
-      :mapId="mapId"
-      :accessToken="accessToken"
-      :mapStyle.sync="mapStyle"
-      :mapOptions="mapOptions"
-      @load="onMapLoaded"
-    >
-      <template v-for="marker in markers">
-        <mb-marker
-          :coordinates="marker.center"
-          :draggable="marker.draggable"
-          @added="onMarkerAdded"
-        >
-          <!-- <v-icon slot="marker" color="blue">mdi-map-marker</v-icon> -->
-        </mb-marker>
-      </template>
-    </mb-map>
-    <button @click="addMarker" style="border: 1px solid">click to add marker Dynamically</button>
-  </div>
+  <v-container fluid fill-height>
+    <v-layout column>
+      <mb-map
+        :mapId="mapId"
+        :accessToken="accessToken"
+        :mapStyle.sync="mapStyle"
+        :mapOptions="mapOptions"
+        @load="onMapLoaded"
+      >
+        <template v-for="(marker, index) in markers">
+          <mb-marker
+            :coordinates="marker.center"
+            :draggable="marker.draggable"
+            @added="onMarkerAdded"
+            v-bind:key="index"
+          >
+            <!-- <v-icon slot="marker" color="blue">mdi-map-marker</v-icon> -->
+          </mb-marker>
+        </template>
+      </mb-map>
+      <button @click="addMarker" style="border: 1px solid">click to add marker Dynamically</button>
+    </v-layout>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -74,7 +77,8 @@ export default class Dynamic extends Vue {
     let center = new LngLat(this.randomLng(), this.randomLat());
     this.markers.push({
       center: center,
-      draggable: Math.random() > 0.5 ? true : false
+      draggable: Math.random() > 0.5 ? true : false,
+      index: this.markers.length - 1,
     });
   }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home">
+  <div class="home box">
     <img alt="Vue logo" src="../assets/logo.png">
     <HelloWorld msg="Welcome to Your Vue.js + TypeScript App"/>
   </div>
@@ -16,3 +16,11 @@ import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
 })
 export default class Home extends Vue {}
 </script>
+
+<style>
+.box {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="box">
-    <img alt="Vue logo" src="../assets/logo.png">
-    <HelloWorld msg="Welcome to Your Vue.js + TypeScript App"/>
+    <v-content >
+      <img alt="Vue logo" src="../assets/logo.png">
+      <HelloWorld msg="Welcome to Your Vue.js + TypeScript App"/>
+    </v-content>
   </div>
 </template>
 
@@ -9,6 +11,12 @@
 import { Component, Vue } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
 
+@Component({
+  components: {
+    HelloWorld,
+  },
+})
+export default class Home extends Vue {}
 </script>
 
 <style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home box">
+  <div class="box">
     <img alt="Vue logo" src="../assets/logo.png">
     <HelloWorld msg="Welcome to Your Vue.js + TypeScript App"/>
   </div>
@@ -9,12 +9,6 @@
 import { Component, Vue } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
 
-@Component({
-  components: {
-    HelloWorld,
-  },
-})
-export default class Home extends Vue {}
 </script>
 
 <style>

--- a/src/views/MapHome.vue
+++ b/src/views/MapHome.vue
@@ -20,12 +20,13 @@
       :mapOptions="mapOptions"
       @load="onMapLoaded"
     >
-      <template v-for="marker in markers">
+      <template v-for="(marker, index) in markers">
         <mb-marker
           :coordinates="marker.center"
           :draggable="marker.draggable"
           :color="marker.color? marker.color:'#9FA8DA'"
           @added="onMarkerAdded"
+          v-bind:key="index"
         >
           <template v-if="marker.custom">
             <v-icon slot="marker" color="red">mdi-map-marker</v-icon>
@@ -130,7 +131,8 @@ export default class MapHome extends Vue {
     let center = new LngLat(this.randomLng(), this.randomLat());
     this.markers.push({
       center: center,
-      draggable: Math.random() > 0.5 ? true : false
+      draggable: Math.random() > 0.5 ? true : false,
+      index: this.markers.length - 1,
     });
   }
   public addCustomMarker() {

--- a/src/views/MapHome.vue
+++ b/src/views/MapHome.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-container fluid>
+  <v-container fluid fill-height>
+    <v-layout column>
     <v-layout wrap align-center>
       <v-flex xs6 sm3 d-flex>
         <v-select v-model="style" :items="mapStyles" label="Change map style"></v-select>
@@ -42,6 +43,7 @@
         </mb-marker>
       </template>
     </mb-map>
+    </v-layout>
   </v-container>
 </template>
 


### PR DESCRIPTION
Instead of static 700px, use responsive 100% height for map container, depending on browser height available


* this includes also some other changes to the code, mostly fixes regarding more scrict typescript conventions

Hi hanbingde, first of all, many thanks for sharing this typescript version of vue-mapbox! I was happy that I didn't have to start from scratch. Here's a pull request where I fixed the 100% height issue (I assume that you used 700px static height because the map was not scaled accurately otherwise).


